### PR TITLE
Fix(Table): Hide emptyText in `Table` when `loading` prop is true

### DIFF
--- a/components/spin/style/index.less
+++ b/components/spin/style/index.less
@@ -3,6 +3,7 @@
 
 @spin-prefix-cls: ~'@{ant-prefix}-spin';
 @spin-dot-default: @text-color-secondary;
+@table-prefix-cls: ~'@{ant-prefix}-table';
 
 .@{spin-prefix-cls} {
   .reset-component();
@@ -107,6 +108,13 @@
     &::after {
       opacity: 0.4;
       pointer-events: auto;
+    }
+
+    // ========================= Placeholder ==========================
+    .@{table-prefix-cls} {
+      &-placeholder {
+        visibility: hidden;
+      }
     }
   }
 


### PR DESCRIPTION
- [x] Bug fix
fixing issue as here, but actually fixed
https://github.com/ant-design/ant-design/pull/9095

https://ant.design/components/table/
When Table component is loading e.g prop loading is true 

We actually see 'No data'
Expected case: we see only spinner
